### PR TITLE
添加移动端社交显示

### DIFF
--- a/footer.ftl
+++ b/footer.ftl
@@ -73,6 +73,36 @@
 		<img src="${(user.avatar)!'${theme_base!}/images/avatar.jpg'}">
 	</div>
 
+	<#if settings.glitch_text??>
+		<p style="text-align: center; color: #333; font-weight: 900; font-family: 'Ubuntu', sans-serif; letter-spacing: 1.5px">${settings.glitch_text}</p>
+	</#if>
+
+	<#if settings.focus_infos!true>
+		<p style="text-align: center; word-spacing: 20px;">
+			<#if settings.twitter??>
+				<a href="${settings.twitter!}" class="fa fa-twitter" target="_blank" style="color: #00aced"></a>
+			</#if>
+			<#if settings.sina??>
+				<a href="${settings.sina!}" class="fa fa-weibo" target="_blank" style="color: #dd4b39"></a>
+			</#if>
+			<#if settings.github??>
+				<a href="${settings.github!}" class="fa fa-github" target="_blank" style="color: #333"></a>
+			</#if>
+			<#if settings.wechat??>
+				<a href="${settings.wechat!}" class="fa fa-wechat" target="_blank" style="color: #333"></a>
+			</#if>
+			<#if settings.qq??>
+				<a href="//wpa.qq.com/msgrd?v=3&uin=${settings.qq!}&site=qq&menu=yes" class="fa fa-qq" target="_blank" style="color: #333"></a>
+			</#if>
+			<#if settings.bili??>
+				<a href="${settings.bili!}" class="fa fa-tv" target="_blank" style="color: #333"></a>
+			</#if>
+			<#if settings.wangyiyun??>
+				<a href="${settings.wangyiyun!}" class="fa fa-music" target="_blank" style="color: #333"></a>
+			</#if>
+		</p>
+	</#if>
+
 	<div class="m-search">
 		<form class="m-search-form" method="get" action="/search" role="search">
 			<input class="m-search-input" type="search" name="keyword" placeholder="搜索..." required>

--- a/settings.yaml
+++ b/settings.yaml
@@ -150,7 +150,7 @@ mainScreen:
       label: 聚焦故障文本
       type: text
       default: 'Hi,Friend'
-      description: '该文本只有头部样式开启故障文字才能显示'
+      description: '移动端：将显示在导航栏中，桌面端：该文本只有头部样式开启故障文字才能显示'
     focus_infos:
       name: focus_infos
       label: 社交信息


### PR DESCRIPTION
1. 添加移动端社交显示（在移动端导航栏中），添加的图标有：twitter 微博 github 微信 qq b站 网易云，使用内置 lib.css 图标样式，未引入其他静态资源
2. 显示上在设置中与桌面端统一，并已在设置中更改描述以说明
