### PR TITLE
修复搜索框的部分问题

### DIFF
--- a/search.ftl
+++ b/search.ftl
@@ -21,7 +21,7 @@
                 </#if>
 			</div>
 			<header class="pattern-header">
-				<h1 class="entry-title search-title i18n" data-iname="page.search.title"></h1>
+				<h1 class="entry-title search-title i18n" data-iname="page.search.title" data-ivalue="${keyword!}"></h1>
 			</header>
 		</div>
 	<#else>
@@ -32,7 +32,7 @@
 <section id="primary" class="content-area">
 	<#if posts?? && posts.content?size gt 0>
 		<main id="main" class="site-main" role="main">
-			<#if !(settings.patternimg!true) || !(settings.searh_patternimg?? && settings.searh_patternimg!='')>
+			<#if !((settings.patternimg!true) && (settings.searh_patternimg?? && settings.searh_patternimg!='') || ((metas.ri?boolean)!true && settings.rimage_cover_sheet_open!true && settings.rimage_url?? && settings.rimage_url!=''))>
 			<header class="page-header">
 				<h1 class="page-title"><span class="i18n" data-iname="page.search.sresult"></span><span>${keyword!}</span></h1>
 			</header><!-- .page-header -->


### PR DESCRIPTION
1. 未定义的关键词
搜索使用随机图时会出现关键词未定义的问题
![image](https://user-images.githubusercontent.com/22992947/103645477-ffc74100-4f92-11eb-941e-770cba562a96.png)

2. 搜索页面使用随机图时和下面的关键字框内容重复
![image](https://user-images.githubusercontent.com/22992947/103645678-5d5b8d80-4f93-11eb-9782-a97ec62a14ce.png)

现调整为：使用随机图时不再显示下面的 `搜索结果：xxx`