### PR TITLE
删除使用随机图时的重复header

### DIFF
--- a/archives.ftl
+++ b/archives.ftl
@@ -35,7 +35,7 @@
 </@header>
 <article class="post-item page type-page status-publish hentry">
     <div id="archives-temp">
-        <#if !(settings.patternimg!true) || !(settings.archives_patternimg?? && settings.archives_patternimg!='')>
+        <#if !((settings.patternimg!true) && (settings.archives_patternimg?? && settings.archives_patternimg!='') || ((metas.ri?boolean)!true && settings.rimage_cover_sheet_open!true && settings.rimage_url?? && settings.rimage_url!=''))>
                 <#if options.archives_title?default("")?trim?length gt 1>
                 <h2>${options.archives_title}</h2>
                 <#else>

--- a/categories.ftl
+++ b/categories.ftl
@@ -48,9 +48,11 @@
     <div id="tags" class="container chip-container" style="margin-top: 0px;">
         <div class="card">
             <div class="card-content">
+                <#if !((settings.patternimg!true) && (settings.category_patternimg?? && settings.category_patternimg!='') || ((metas.ri?boolean)!true && settings.rimage_cover_sheet_open!true && settings.rimage_url?? && settings.rimage_url!=''))>
                 <div class="tag-title center-align">
                     <i class="fa fa-bookmark"></i>&nbsp;&nbsp;<span class="i18n" data-iname="page.categories.title"></span>
                 </div>
+                </#if>
                 <div class="tag-chips">
                 <@categoryTag method="list">
                 <#list categories as category>

--- a/category.ftl
+++ b/category.ftl
@@ -34,7 +34,7 @@
 <div id="primary" class="content-area">
     <main id="main" class="site-main" role="main">
         <#if posts?? && posts.content?size gt 0>
-            <#if !(settings.patternimg!true) || !((category.thumbnail?? && category.thumbnail!='') || (settings.category_patternimg?? && settings.category_patternimg!=''))>
+            <#if !((settings.patternimg!true) && ((category.thumbnail?? && category.thumbnail!='') || (settings.category_patternimg?? && settings.category_patternimg!='')) || ((metas.ri?boolean)!true && settings.rimage_cover_sheet_open!true && settings.rimage_url?? && settings.rimage_url!=''))>
                 <header class="page-header">
                     <h1 class="cat-title">${category.name!}</h1>
                     <span class="cat-des">

--- a/sheet_links.ftl
+++ b/sheet_links.ftl
@@ -27,6 +27,15 @@
 		</div>
 	<#else>
 		<div class="blank"></div>
+        <header class="entry-header">
+        <h1 class="entry-title">
+            <#if options.links_title?default("")?trim?length gt 1>
+			<span>${options.links_title}</span>
+			<#else>
+			<span class="i18n" data-iname="page.links.title"></span>
+            </#if>
+        </h1>
+        </header><!-- .entry-header -->
 		<style>
             .toc-container {
                 top: 210px;

--- a/tag.ftl
+++ b/tag.ftl
@@ -40,7 +40,7 @@
 <div id="primary" class="content-area">
     <main id="main" class="site-main" role="main">
         <#if posts?? && posts.content?size gt 0>
-            <#if !(settings.patternimg!true) || !((tag.thumbnail?? && tag.thumbnail!='') || (settings.tag_patternimg?? && settings.tag_patternimg!=''))>
+            <#if !((settings.patternimg!true) && ((tag.thumbnail?? && tag.thumbnail!='') || (settings.tag_patternimg?? && settings.tag_patternimg!='')) || ((metas.ri?boolean)!true && settings.rimage_cover_sheet_open!true && settings.rimage_url?? && settings.rimage_url!=''))>
                 <header class="page-header">
                     <h1 class="cat-title">${tag.name!}</h1>
                     <span class="cat-des">

--- a/tags.ftl
+++ b/tags.ftl
@@ -68,9 +68,11 @@
     <div id="tags" class="container chip-container">
         <div class="card">
             <div class="card-content">
+                <#if !((settings.patternimg!true) && (settings.tag_patternimg?? && settings.tag_patternimg!='') || ((metas.ri?boolean)!true && settings.rimage_cover_sheet_open!true && settings.rimage_url?? && settings.rimage_url!=''))>
                 <div class="tag-title center-align">
                     <i class="fa fa-tags"></i>&nbsp;&nbsp;<span class="i18n" data-iname="page.tags.title"></span>
                 </div>
+                </#if>
                 <div class="tag-chips">
                 <@tagTag method="list">
                 <#list tags as tag>

--- a/tpl/content-justify-photos.ftl
+++ b/tpl/content-justify-photos.ftl
@@ -1,5 +1,5 @@
 <section>
-    <#if !(settings.patternimg!true) || !(settings.photos_patternimg?? && settings.photos_patternimg!='')>
+    <#if !((settings.patternimg!true) && (settings.photos_patternimg?? && settings.photos_patternimg!='') || ((metas.ri?boolean)!true && settings.rimage_cover_sheet_open!true && settings.rimage_url?? && settings.rimage_url!=''))>
     <header class="entry-header">
         <h1 class="entry-title">
         	<#if options.photos_title?default("")?trim?length gt 1>

--- a/tpl/content-links.ftl
+++ b/tpl/content-links.ftl
@@ -1,15 +1,4 @@
 <article>
-    <#if !(settings.patternimg!true) || (!(settings.links_patternimg?? && settings.links_patternimg!='') && !(is_sheet?? && sheet.thumbnail?? && sheet.thumbnail!=''))>
-    <header class="entry-header">
-        <h1 class="entry-title">
-            <#if options.links_title?default("")?trim?length gt 1>
-			<span>${options.links_title}</span>
-			<#else>
-			<span class="i18n" data-iname="page.links.title"></span>
-            </#if>
-        </h1>
-    </header><!-- .entry-header -->
-    </#if>
     <#if is_sheet??>
      ${sheet.formatContent!}
     </#if>

--- a/tpl/content-masonry-photos.ftl
+++ b/tpl/content-masonry-photos.ftl
@@ -1,5 +1,5 @@
 <section>
-    <#if !(settings.patternimg!true) || !(settings.photos_patternimg?? && settings.photos_patternimg!='')>
+    <#if !((settings.patternimg!true) && (settings.photos_patternimg?? && settings.photos_patternimg!='') || ((metas.ri?boolean)!true && settings.rimage_cover_sheet_open!true && settings.rimage_url?? && settings.rimage_url!=''))>
     <header class="entry-header">
         <h1 class="entry-title">
             <#if options.photos_title?default("")?trim?length gt 1>

--- a/tpl/content-page.ftl
+++ b/tpl/content-page.ftl
@@ -2,7 +2,7 @@
     @package Akina
 -->
 <article id="post-${sheet.id!}" class="post-item post-${sheet.id} page type-page status-publish hentry">
-    <#if !(settings.patternimg!true) || !(sheet.thumbnail?? && sheet.thumbnail!='')>
+    <#if !((settings.patternimg!true) && (sheet.thumbnail?? && sheet.thumbnail!='') || ((metas.ri?boolean)!true && settings.rimage_cover_sheet_open!true && settings.rimage_url?? && settings.rimage_url!=''))>
         <header class="entry-header">
             <h1 class="entry-title">${sheet.title!}</h1>
         </header><!-- .entry-header -->

--- a/tpl/content-single.ftl
+++ b/tpl/content-single.ftl
@@ -2,7 +2,7 @@
     @package Akina
 -->
 <article id="post-${post.id?c}">
-    <#if !(settings.patternimg!true) || !(post.thumbnail?? && post.thumbnail!='')>
+    <#if !((settings.patternimg!true) && (post.thumbnail?? && post.thumbnail!='') || ((metas.ri?boolean)!true && settings.rimage_cover_open!true && settings.rimage_url?? && settings.rimage_url!=''))>
         <header class="entry-header">
             <h1 class="entry-title">${post.title!}</h1>
             <p class="entry-census">${post.createTime?string('yyyy-MM-dd')}


### PR DESCRIPTION
如果对文章启用随即图，文章页面出现重复的标题

![image](https://user-images.githubusercontent.com/22992947/103881039-dfbf8b00-5114-11eb-8a40-3ec507162e9e.png)