### PR TITLE
fix: 修改文章详情页中的作者信息显示名

### DIFF
--- a/templates/module/authorprofile.html
+++ b/templates/module/authorprofile.html
@@ -10,7 +10,7 @@
       </a>
       <div class="meta">
         <h3 itemprop="name">
-          <a th:href="${site.url}" itemprop="url" rel="author" th:text="${post.owner.name}" aria-label="website address"></a>
+          <a th:href="${site.url}" itemprop="url" rel="author" th:text="${post.owner.displayName}" aria-label="website address"></a>
         </h3>
       </div>
     </div>


### PR DESCRIPTION

Fixes #356 

```release-note
修改文章详情页中的作者信息为显示名称
```