### PR TITLE
始终展示聚焦故障文本选项 fixes #399

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -135,7 +135,6 @@ spec:
           name: glitch_text
           id: glitch_text
           key: glitch_text
-          if: "$get(focus_tou).value == 'glitch-text'"
           label: 聚焦故障文本
           value: Hi,Friend
           help: 移动端：将显示在导航栏中，桌面端：该文本只有头部样式开启故障文字才能显示


### PR DESCRIPTION
即使关闭首屏功能，该选项的内容仍会用于移动端导航栏，因此应该始终展示
不过如果这样不清楚放在首屏选项卡中是否合适