### PR TITLE
fix: 删除默认 meting api 接口多余的 ? 号参数

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -957,7 +957,7 @@ spec:
           if: "$get(aplayer_float).value == true"
           name: aplayer_host
           label: Meting API 地址
-          value:  https://api.injahow.cn/meting/?
+          value:  https://api.injahow.cn/meting/
           help: 支持 Meting 类型格式的 API，主题不保证 API 可用度，如无法使用请自行搭建。 https://github.com/injahow/meting-api
         - $formkit: select
           if: "$get(aplayer_float).value == true"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

解决由于默认的 meting url 多了一个 ? 号参数而导致的 QQ 音乐接口报错问题。

#### Which issue(s) this PR fixes:

Fixes #446 

#### Does this PR introduce a user-facing change?
```release-note
解决 QQ 音乐接口报错的问题
```
