### PR TITLE
fix: 解决个人资料跳转链接不正确的问题

### DIFF
--- a/templates/module/header/user.html
+++ b/templates/module/header/user.html
@@ -17,7 +17,7 @@
       </div>
       <div class="user-menu-option">
         <!-- 个人资料 -->
-        <a href="/console/users/-/detail" target="_blank" data-i18n="user.info" aria-label="access the personal profile page"></a>
+        <a href="/uc/profile" target="_blank" data-i18n="user.info" aria-label="access the personal profile page"></a>
         <!-- 退出登录 -->
         <a href="/logout" target="_top" data-i18n="user.logout" aria-label="log out of the account"></a>
       </div>

--- a/theme.yaml
+++ b/theme.yaml
@@ -18,6 +18,6 @@ spec:
   settingName: theme-sakura-setting
   configMapName: theme-sakura-configMap
   version: 2.0.0
-  require: ">=2.6.0"
+  require: ">=2.11.0"
 metadata:
   name: theme-sakura


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

在 2.11 后实现了个人中心的功能，因此将主题依赖提升至 2.11 并修改了个人资料的跳转链接为个人中心

#### Which issue(s) this PR fixes:

Fixes #441 

#### Does this PR introduce a user-facing change?
```release-note
升级 Halo 依赖至 2.11 并修复个人资料跳转链接的问题
```
