### PR TITLE
feat: 自定义文章协议功能

### DIFF
--- a/annotation-setting.yaml
+++ b/annotation-setting.yaml
@@ -52,9 +52,11 @@ spec:
       on-value: "true"
       off-value: "false"
     - $formkit: text
+      if: "$get(post_license).value == 'true'"
       name: post_license_text
       label: 授权协议
     - $formkit: text
+      if: "$get(post_license).value == 'true'"
       name: post_license_url
       label: 协议链接
 

--- a/annotation-setting.yaml
+++ b/annotation-setting.yaml
@@ -44,6 +44,19 @@ spec:
       value: "true"
       on-value: "true"
       off-value: "false"
+    - $formkit: checkbox
+      name: post_license
+      id: post_license
+      label: 自定义授权协议
+      value: "false"
+      on-value: "true"
+      off-value: "false"
+    - $formkit: text
+      name: post_license_text
+      label: 授权协议
+    - $formkit: text
+      name: post_license_url
+      label: 协议链接
 
 ---
 

--- a/settings.yaml
+++ b/settings.yaml
@@ -409,12 +409,16 @@ spec:
           label: 自定义全局授权协议
           value: false
         - $formkit: text
-          if: "$get(post_license).value == true"
+          if: "$get(post_license).value === true"
           name: post_license_text
+          id: post_license_text
+          key: post_license_text
           label: 授权协议
         - $formkit: text
-          if: "$get(post_license).value == true"
+          if: "$get(post_license).value === true"
           name: post_license_url
+          id: post_license_url
+          key: post_license_url
           label: 协议链接
         - $formkit: checkbox
           name: post_auto_collapse

--- a/settings.yaml
+++ b/settings.yaml
@@ -404,6 +404,19 @@ spec:
       label: 文章页
       formSchema:
         - $formkit: checkbox
+          name: post_license
+          id: post_license
+          label: 自定义全局授权协议
+          value: false
+        - $formkit: text
+          if: "$get(post_license).value == true"
+          name: post_license_text
+          label: 授权协议
+        - $formkit: text
+          if: "$get(post_license).value == true"
+          name: post_license_url
+          label: 协议链接
+        - $formkit: checkbox
           name: post_auto_collapse
           label: 导航栏自动收起
           value: true

--- a/templates/macro/content-post.html
+++ b/templates/macro/content-post.html
@@ -54,24 +54,23 @@
       <div class="post-footer-meta">
         <div class="post-license" itemprop="license">
           <a class="flex-child-center"
-             th:if="!${#annotations.get(post, 'post_license')}"
-             th:href="${theme.config.post.post_license ? theme.config.post.post_license_url : 'https://creativecommons.org/licenses/by-nc-sa/4.0/'}"
+             th:with="hasPostLicense = ${#annotations.getOrDefault(post, 'post_license', 'false')}"
+             th:href="${hasPostLicense ? #annotations.getOrDefault(post, 'post_license_url', '') : (theme.config.post.post_license ? theme.config.post.post_license_url : 'https://creativecommons.org/licenses/by-nc-sa/4.0/')}"
              target="_blank"
              rel="nofollow"
              aria-label="accessing the Creative Commons License">
             <span class="iconify" data-icon="fa:creative-commons"></span>
-            <th:block th:if="${theme.config.post.post_license}">
-              <span th:text="${theme.config.post.post_license_text}"></span>
+            <th:block th:if="${hasPostLicense}">
+              <span th:text="${#annotations.getOrDefault(post, 'post_license_text', '')}"></span>
             </th:block>
-            <th:block th:unless="${theme.config.post.post_license}">
-              <span data-i18n="post.license"></span>
+            <th:block th:unless="${hasPostLicense}">
+              <th:block th:if="${theme.config.post.post_license}">
+                <span th:text="${theme.config.post.post_license_text}"></span>
+              </th:block>
+              <th:block th:unless="${theme.config.post.post_license}">
+                <span data-i18n="post.license"></span>
+              </th:block>
             </th:block>
-          </a>
-          <a th:if="${#annotations.get(post, 'post_license')}" class="flex-child-center"
-             th:href="${#annotations.get(post, 'post_license_url')}" target="_blank" rel="nofollow"
-             aria-label="accessing the Creative Commons License">
-            <span class="iconify" data-icon="fa:creative-commons"></span>
-            <span th:text="${#annotations.get(post, 'post_license_text')}"></span>
           </a>
         </div>
         <div class="post-tags flex-child-center">

--- a/templates/macro/content-post.html
+++ b/templates/macro/content-post.html
@@ -53,10 +53,17 @@
       </div>
       <div class="post-footer-meta">
         <div class="post-license" itemprop="license">
-          <a class="flex-child-center" href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank" rel="nofollow"
-            aria-label="accessing the Creative Commons License">
+          <a th:if="!${#annotations.get(post, 'post_license')}" class="flex-child-center"
+             href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank" rel="nofollow"
+             aria-label="accessing the Creative Commons License">
             <span class="iconify" data-icon="fa:creative-commons"></span>
             <span data-i18n="post.license"></span>
+          </a>
+          <a th:if="${#annotations.get(post, 'post_license')}" class="flex-child-center"
+             th:href="${#annotations.get(post, 'post_license_url')}" target="_blank" rel="nofollow"
+             aria-label="accessing the Creative Commons License">
+            <span class="iconify" data-icon="fa:creative-commons"></span>
+            <span th:text="${#annotations.get(post, 'post_license_text')}"></span>
           </a>
         </div>
         <div class="post-tags flex-child-center">

--- a/templates/macro/content-post.html
+++ b/templates/macro/content-post.html
@@ -53,11 +53,19 @@
       </div>
       <div class="post-footer-meta">
         <div class="post-license" itemprop="license">
-          <a th:if="!${#annotations.get(post, 'post_license')}" class="flex-child-center"
-             href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank" rel="nofollow"
+          <a class="flex-child-center"
+             th:if="!${#annotations.get(post, 'post_license')}"
+             th:href="${theme.config.post.post_license ? theme.config.post.post_license_url : 'https://creativecommons.org/licenses/by-nc-sa/4.0/'}"
+             target="_blank"
+             rel="nofollow"
              aria-label="accessing the Creative Commons License">
             <span class="iconify" data-icon="fa:creative-commons"></span>
-            <span data-i18n="post.license"></span>
+            <th:block th:if="${theme.config.post.post_license}">
+              <span th:text="${theme.config.post.post_license_text}"></span>
+            </th:block>
+            <th:block th:unless="${theme.config.post.post_license}">
+              <span data-i18n="post.license"></span>
+            </th:block>
           </a>
           <a th:if="${#annotations.get(post, 'post_license')}" class="flex-child-center"
              th:href="${#annotations.get(post, 'post_license_url')}" target="_blank" rel="nofollow"


### PR DESCRIPTION
feat：#527 
- 可自定义全局文章协议
- 可自定义单独文章协议
- 默认使用主题自带协议
- 单篇文章的转载可标注
- 多信息来源建议文章内标注，协议标注转载提示
---
## 全局
![image](https://github.com/user-attachments/assets/43b40f28-fa61-4495-89f0-854d3c1c5ff5)
---
## 单独
![image](https://github.com/user-attachments/assets/e6d74783-d849-41b5-b7b6-5663420c0bea)
