### PR TITLE
fix: set iconify value-only for menu item annotation

### DIFF
--- a/annotation-setting.yaml
+++ b/annotation-setting.yaml
@@ -11,6 +11,7 @@ spec:
       name: "icon"
       format: name
       label: "图标"
+      value-only: true
     - $formkit: "text"
       name: "animation"
       label: "动画"


### PR DESCRIPTION
## 修改内容

为菜单项图标的 `iconify` 配置添加 `value-only: true`。

## 说明

当前未设置 `value-only: true` 时，`iconify` 会返回对象，导致 Halo 后端保存菜单项时报类型转换错误。添加该配置后，图标值会以字符串形式提交

## Fixed issue

Fixes #654