### PR TITLE
fix: use string values for switch in annotation settings

### DIFF
--- a/annotation-setting.yaml
+++ b/annotation-setting.yaml
@@ -30,28 +30,36 @@ spec:
     - $formkit: switch
       name: randomImage
       label: 使用随机封面
-      value: true
+      value: "true"
+      onValue: "true"
+      offValue: "false"
     - $formkit: switch
       name: toc
       label: 自动生成目录
-      value: true
+      value: "true"
+      onValue: "true"
+      offValue: "false"
     - $formkit: switch
       name: original
       id: original
       label: 原创文章
-      value: false
+      value: "false"
+      onValue: "true"
+      offValue: "false"
     - $formkit: switch
-      if: "$get(original).value == true"
+      if: "$get(original).value === 'true'"
       name: post_license
       id: post_license
       label: 自定义授权协议
-      value: false
+      value: "false"
+      onValue: "true"
+      offValue: "false"
     - $formkit: text
-      if: "$get(post_license).value == true"
+      if: "$get(post_license).value === 'true'"
       name: post_license_text
       label: 授权协议
     - $formkit: text
-      if: "$get(post_license).value == true"
+      if: "$get(post_license).value === 'true'"
       name: post_license_url
       label: 协议链接
 
@@ -69,13 +77,17 @@ spec:
     - $formkit: switch
       name: randomImage
       label: 使用随机图
-      value: true
+      value: "true"
+      onValue: "true"
+      offValue: "false"
 
     - $formkit: switch
       name: toc
       label: 自动生成目录
-      value: true
-      
+      value: "true"
+      onValue: "true"
+      offValue: "false"
+
 ---
 
 apiVersion: v1alpha1


### PR DESCRIPTION
## 修改内容

为文章/独立页面元数据中的所有 `switch` 字段显式设置字符串类型的 `onValue: "true"` 与 `offValue: "false"`，并将默认值 `value` 同步改为字符串；同时将联动字段的条件表达式由 `$get(...).value == true` 调整为 `$get(...).value === 'true'`。

## 说明

Annotation 的值只能是字符串类型，而 `switch` 组件的 `onValue`/`offValue` 默认为布尔值 `true`/`false`，导致 Console 端编辑文章时，从 annotation 读取到的字符串 `"true"` 与布尔值不匹配，开关组件无法正确回显渲染。按文档显式指定字符串开关值即可修复：https://docs.halo.run/developer-guide/form-schema#switch

存入 annotation 的值仍为 `"true"`/`"false"` 字符串，模板侧 `#annotations.getOrDefault(...)` 的既有用法不受影响。

## Fixed issue

Fixes #657