### PR TITLE
fix: restore header decoration image for search page

### DIFF
--- a/templates/search.html
+++ b/templates/search.html
@@ -7,14 +7,19 @@
     <th:block th:text="${searchResult.keyword} + '|' + ${site.title}"></th:block>
   </th:block>
 
+  <th:block th:fragment="header">
+    <th:block
+      th:replace="~{macro/page-header :: page-header(frontCover=${theme.config.patternimg.searh_patternimg}, headerTitle = ~{::headerTitle}, id='search', isRandomImage=true)}"
+    />
+  </th:block>
+
+  <th:block th:fragment="headerTitle">
+    <h1 data-i18n="search.search_result.title" th:i18n-options="|{keyword: '${searchResult.keyword}'}|"></h1>
+  </th:block>
+
   <th:block th:fragment="content">
     <div class="search-container">
       <th:block th:if="${searchResult.total gt 0}">
-        <h1
-          class="search-title"
-          data-i18n="search.search_result.title"
-          th:i18n-options="|{keyword: '${searchResult.keyword}'}|"
-        ></h1>
         <th:block th:each="document : ${searchResult.hits}">
           <th:block th:replace="~{module/search/search-item :: item(${document})}" />
         </th:block>

--- a/templates/search.html
+++ b/templates/search.html
@@ -9,7 +9,7 @@
 
   <th:block th:fragment="header">
     <th:block
-      th:replace="~{macro/page-header :: page-header(frontCover=${theme.config.patternimg.searh_patternimg}, headerTitle = ~{::headerTitle}, id='search', isRandomImage=true)}"
+      th:replace="~{macro/page-header :: page-header(extension=${null}, frontCover=${theme.config.patternimg.searh_patternimg}, headerTitle = ~{::headerTitle}, id='search', isRandomImage=true)}"
     />
   </th:block>
 


### PR DESCRIPTION
## 修改内容

为搜索页添加页头，通过 `macro/page-header` 引用「搜索页装饰图」设置（`patternimg.searh_patternimg`），未设置装饰图时可回退使用随机封面图；同时将搜索结果标题移至页头展示（装饰图存在时标题浮于图上），与归档、友链等页面行为保持一致。

## 说明

搜索页模板向布局传递了 `_header` 参数，但从未定义 `header` 片段，导致「搜索页装饰图」设置项从未被任何模板引用，设置后不生效。该问题源于 Halo 2 移植时重写搜索页（#544）遗漏了 1.x 模板中的页头。

## Fixed issue

Fixes #653