### PR TITLE
fix: use explicit srcset and sizes for home background image

### DIFF
--- a/templates/module/home/img_box.html
+++ b/templates/module/home/img_box.html
@@ -22,10 +22,16 @@
   </th:block>
   <th:block
     th:unless="${theme.config.random_image.rimage_cover_back_open and (not #strings.isEmpty(theme.config.random_image.rimage_url))}"
+    th:with="bgImage = ${theme.config.mainScreen.focus_img_1 ?: #theme.assets('/images/default/hd.webp')}"
   >
     <img
       class="cover-bg"
-      th:src="${theme.config.mainScreen.focus_img_1 ?: #theme.assets('/images/default/hd.webp')}"
+      th:src="${bgImage}"
+      th:srcset="|${thumbnail.gen(bgImage, 's')} 400w,
+                  ${thumbnail.gen(bgImage, 'm')} 800w,
+                  ${thumbnail.gen(bgImage, 'l')} 1200w,
+                  ${thumbnail.gen(bgImage, 'xl')} 1600w|"
+      sizes="100vw"
       alt="background picture of the home page"
       width="1920"
       height="1080"


### PR DESCRIPTION
## 修改内容

为首页首屏背景图 `<img>` 手动声明 `srcset`（`thumbnail.gen` 四档缩略图）与 `sizes="100vw"`，避免 Halo 自动响应式图片功能按默认 `sizes` 为其选取过小的缩略图。

## 说明

Halo 2.22 起会自动为没有 `srcset` 的 `<img>` 注入缩略图 `srcset` 与默认 `sizes`（大屏时为 `min(800px, 85vw)`），全屏渲染的首页背景图因此在桌面端被替换为约 800px 宽的缩略图，导致画面模糊。手动声明 `srcset` 后 Halo 会跳过该标签，浏览器可按真实渲染宽度（100vw）选取 1600w 缩略图；对于无缩略图的图片（webp、外链、主题默认图），`thumbnail.gen` 会原样返回原图地址，行为与之前一致。

## Fixed issue

Fixes #652