### PR TITLE
修复模块重复加载导致的主题切换与播放器异常

### DIFF
--- a/templates/scripts/index.html
+++ b/templates/scripts/index.html
@@ -1,12 +1,12 @@
 <!--/* 主题 js */-->
 <th:block th:fragment="scripts">
   <!--/* 基础 JS */-->
-  <script type="module" async th:src="@{/assets/dist/main-{version}.min.js(version=${theme.spec.version})}"></script>
+  <script type="module" async th:src="@{/assets/dist/main-{version}.min.js}"></script>
 
   <!--/* PJAX */-->
-  <script type="module" async th:if="${theme.config.others.poi_pjax}" th:src="@{/assets/dist/libs/pjax-{version}.min.js(version=${theme.spec.version})}"></script>
+  <script type="module" async th:if="${theme.config.others.poi_pjax}" th:src="@{/assets/dist/libs/pjax-{version}.min.js}"></script>
 
-  <script type="module" async th:src="@{/assets/dist/libs/lazysizes-{version}.min.js(version=${theme.spec.version})}"></script>
+  <script type="module" async th:src="@{/assets/dist/libs/lazysizes-{version}.min.js}"></script>
 
   <script type="text/javascript" th:inline="javascript">
     function imgError(dom) {


### PR DESCRIPTION
修复两个同根因的问题：点击主题切换无反应、吸底 APlayer 展开后样式损坏。

根因：模板中 module script 的 URL 带有 `?v=` 查询参数，而 pjax 产物内部 import 的是无查询参数的裸路径，浏览器将 `main.js` 当作两个模块加载执行了两次，导致主题切换按钮被绑定两个相同监听器（点击时 show 类被切换两次，相互抵消），且 APlayer 在同一个容器中被实例化两次。

修复：移除 module script 标签中冗余的 `(version=...)` 查询参数（版本号已在文件名中，不影响缓存失效），使 script URL 与产物内部 import 路径完全一致。