### PR TITLE
fix: preserve original home background image on desktop

### DIFF
--- a/templates/module/home/img_box.html
+++ b/templates/module/home/img_box.html
@@ -24,18 +24,21 @@
     th:unless="${theme.config.random_image.rimage_cover_back_open and (not #strings.isEmpty(theme.config.random_image.rimage_url))}"
     th:with="bgImage = ${theme.config.mainScreen.focus_img_1 ?: #theme.assets('/images/default/hd.webp')}"
   >
-    <img
-      class="cover-bg"
-      th:src="${bgImage}"
-      th:srcset="|${thumbnail.gen(bgImage, 's')} 400w,
-                  ${thumbnail.gen(bgImage, 'm')} 800w,
-                  ${thumbnail.gen(bgImage, 'l')} 1200w,
-                  ${thumbnail.gen(bgImage, 'xl')} 1600w|"
-      sizes="100vw"
-      alt="background picture of the home page"
-      width="1920"
-      height="1080"
-    />
+    <picture>
+      <source media="(min-width: 769px)" th:srcset="${bgImage}" />
+      <img
+        class="cover-bg"
+        th:src="${bgImage}"
+        th:srcset="|${thumbnail.gen(bgImage, 's')} 400w,
+                    ${thumbnail.gen(bgImage, 'm')} 800w,
+                    ${thumbnail.gen(bgImage, 'l')} 1200w,
+                    ${thumbnail.gen(bgImage, 'xl')} 1600w|"
+        sizes="100vw"
+        alt="background picture of the home page"
+        width="1920"
+        height="1080"
+      />
+    </picture>
   </th:block>
 
   <div class="focusinfo">


### PR DESCRIPTION
#### What this PR does / why we need it:

在首页首屏背景图中使用 `<picture>` 区分桌面端和移动端资源：

- 桌面端直接加载配置的原图，避免受到 1600px 缩略图上限影响。
- 移动端继续根据屏幕宽度加载响应式缩略图，兼顾清晰度与加载性能。
- 延续 #660 对 Halo 自动响应式图片处理的适配。

#### Which issue(s) this PR fixes:

Fixes #652

#### Does this PR introduce a user-facing change?
```release-note
优化首页首屏背景图清晰度，桌面端使用原图，移动端继续按屏幕尺寸加载缩略图。
```
