### PR TITLE
fix: avoid duplicate main script initialization

### DIFF
--- a/templates/scripts/index.html
+++ b/templates/scripts/index.html
@@ -1,7 +1,10 @@
 <!--/* 主题 js */-->
 <th:block th:fragment="scripts">
   <!--/* 基础 JS */-->
-  <script type="module" async th:src="@{/assets/dist/main-{version}.min.js(version=${theme.spec.version})}"></script>
+  <script
+    type="module"
+    async
+    th:src="@{|/themes/${theme.metadata.name}/assets/dist/main-${theme.spec.version}.min.js|}"></script>
 
   <!--/* PJAX */-->
   <script type="module" async th:if="${theme.config.others.poi_pjax}" th:src="@{/assets/dist/libs/pjax-{version}.min.js(version=${theme.spec.version})}"></script>


### PR DESCRIPTION
#### What this PR does / why we need it:

统一主题主入口与 Vite 静态导入的模块 URL，避免脚本因查询参数不同而重复初始化，导致主题切换事件执行两次。

#### Does this PR introduce a user-facing change?
```release-note
修复“切换主题”按钮点击后没有反应的问题。
```